### PR TITLE
Allow for the source dataset to be specified in the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 OECM-images
 TPI-images
 
+# Test output paths
+
+**/test_output/**
 
 # Local node cache
 node_modules

--- a/src/hazard/cli.py
+++ b/src/hazard/cli.py
@@ -7,7 +7,7 @@ from hazard.sources import SourceDataset
 
 
 def days_tas_above_indicator(
-    source_dataset: SourceDataset = "",
+    source_dataset: SourceDataset = "NEX-GDDP-CMIP6",
     source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],
@@ -39,7 +39,7 @@ def days_tas_above_indicator(
 
 
 def degree_days_indicator(
-    source_dataset: SourceDataset = "",
+    source_dataset: SourceDataset = "NEX-GDDP-CMIP6",
     source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],

--- a/src/hazard/cli.py
+++ b/src/hazard/cli.py
@@ -1,11 +1,14 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import fire
 
 from hazard import services as hazard_services
+from hazard.sources import SourceDataset
 
 
 def days_tas_above_indicator(
+    source_dataset: SourceDataset = "",
+    source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],
     threshold_list: List[float] = [20],
@@ -18,8 +21,9 @@ def days_tas_above_indicator(
     inventory_format: Optional[str] = "osc",
     extra_xarray_store: Optional[bool] = False,
 ):
-
     hazard_services.days_tas_above_indicator(
+        source_dataset,
+        source_dataset_kwargs,
         gcm_list,
         scenario_list,
         threshold_list,
@@ -35,6 +39,8 @@ def days_tas_above_indicator(
 
 
 def degree_days_indicator(
+    source_dataset: SourceDataset = "",
+    source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],
     threshold_temperature: float = 32,
@@ -47,8 +53,9 @@ def degree_days_indicator(
     extra_xarray_store: Optional[bool] = False,
     inventory_format: Optional[str] = "osc",
 ):
-
     hazard_services.degree_days_indicator(
+        source_dataset,
+        source_dataset_kwargs,
         gcm_list,
         scenario_list,
         threshold_temperature,

--- a/src/hazard/services.py
+++ b/src/hazard/services.py
@@ -1,5 +1,5 @@
 import logging  # noqa: E402
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 from dask.distributed import Client, LocalCluster  # noqa: E402
 from fsspec.implementations.local import LocalFileSystem
@@ -7,7 +7,7 @@ from fsspec.implementations.local import LocalFileSystem
 from hazard.docs_store import DocStore  # type: ignore # noqa: E402
 from hazard.models.days_tas_above import DaysTasAboveIndicator  # noqa: E402
 from hazard.models.degree_days import DegreeDays  # noqa: E402
-from hazard.sources.nex_gddp_cmip6 import NexGddpCmip6  # noqa: E402
+from hazard.sources import SourceDataset, get_source_dataset_instance
 from hazard.sources.osc_zarr import OscZarr  # noqa: E402
 
 logging.basicConfig(
@@ -17,6 +17,8 @@ logging.basicConfig(
 
 
 def days_tas_above_indicator(
+    source_dataset: SourceDataset = "",
+    source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],
     threshold_list: List[float] = [20],
@@ -39,7 +41,8 @@ def days_tas_above_indicator(
 
     docs_store, target, client = setup(bucket, prefix, store, extra_xarray_store)
 
-    source = NexGddpCmip6()
+    source_dataset_kwargs = {} if source_dataset_kwargs is None else source_dataset_kwargs
+    source = get_source_dataset_instance(source_dataset, source_dataset_kwargs)
 
     model = DaysTasAboveIndicator(
         threshold_temps_c=threshold_list,
@@ -59,6 +62,8 @@ def days_tas_above_indicator(
 
 
 def degree_days_indicator(
+    source_dataset: SourceDataset = "",
+    source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],
     threshold_temperature: float = 32,
@@ -81,7 +86,8 @@ def degree_days_indicator(
 
     docs_store, target, client = setup(bucket, prefix, store, extra_xarray_store)
 
-    source = NexGddpCmip6()
+    source_dataset_kwargs = {} if source_dataset_kwargs is None else source_dataset_kwargs
+    source = get_source_dataset_instance(source_dataset, source_dataset_kwargs)
 
     model = DegreeDays(
         threshold=threshold_temperature,
@@ -105,7 +111,7 @@ def setup(
     prefix: Optional[str] = None,
     store: Optional[str] = None,
     extra_xarray_store: Optional[bool] = False,
-) -> Tuple[Union[DocStore, OscZarr, Client]]:
+) -> Tuple[DocStore, OscZarr, Client]:
     """
     initialize output store, docs store and local dask client
     """

--- a/src/hazard/services.py
+++ b/src/hazard/services.py
@@ -17,7 +17,7 @@ logging.basicConfig(
 
 
 def days_tas_above_indicator(
-    source_dataset: SourceDataset = "",
+    source_dataset: SourceDataset = "NEX-GDDP-CMIP6",
     source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],
@@ -62,7 +62,7 @@ def days_tas_above_indicator(
 
 
 def degree_days_indicator(
-    source_dataset: SourceDataset = "",
+    source_dataset: SourceDataset = "NEX-GDDP-CMIP6",
     source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],

--- a/src/hazard/sources/__init__.py
+++ b/src/hazard/sources/__init__.py
@@ -1,16 +1,16 @@
-from typing import TypeAlias, Literal, Mapping, Dict, Any, Protocol, Type
+from typing import Literal, Mapping, Dict, Any, Protocol, Type, Callable
 
 from hazard.protocols import OpenDataset
 from hazard.sources.nex_gddp_cmip6 import NexGddpCmip6
 from hazard.sources.ukcp18_rcp85 import Ukcp18Rcp85
 from hazard.sources.wri_aqueduct import WRIAqueductSource
 
-SourceDataset: TypeAlias = Literal[
+SourceDataset = Literal[
     "NEX-GDDP-CMIP6",
     "UKCP18",
 ]
 
-_SOURCE_DATASETS: Mapping[str, Type[Protocol]] = {
+_SOURCE_DATASETS: Mapping[str, Callable[..., OpenDataset]] = {
     "NEX-GDDP-CMIP6": NexGddpCmip6,
     "UKCP18": Ukcp18Rcp85,
 }

--- a/src/hazard/sources/__init__.py
+++ b/src/hazard/sources/__init__.py
@@ -1,0 +1,22 @@
+from typing import TypeAlias, Literal, Mapping, Dict, Any, Protocol, Type
+
+from hazard.protocols import OpenDataset
+from hazard.sources.nex_gddp_cmip6 import NexGddpCmip6
+from hazard.sources.ukcp18_rcp85 import Ukcp18Rcp85
+from hazard.sources.wri_aqueduct import WRIAqueductSource
+
+SourceDataset: TypeAlias = Literal[
+    "NEX-GDDP-CMIP6",
+    "UKCP18",
+]
+
+_SOURCE_DATASETS: Mapping[str, Type[Protocol]] = {
+    "NEX-GDDP-CMIP6": NexGddpCmip6,
+    "UKCP18": Ukcp18Rcp85,
+}
+
+
+def get_source_dataset_instance(source_dataset: SourceDataset, source_dataset_kwargs: Dict[str, Any]) -> OpenDataset:
+    if source_dataset not in _SOURCE_DATASETS:
+        raise ValueError(f"Invalid source dataset: {source_dataset}")
+    return _SOURCE_DATASETS[source_dataset](**source_dataset_kwargs)


### PR DESCRIPTION
# What this PR is

This PR adds the ability to decide the source dataset (`OpenDataset`) implementation when invoking the CLI to generate indicators. Previously the `NextGddpCmip6` dataset was hardcoded, now we have a mapping to be able to extend support when we implement more datasets.

I've also allowed for kwargs to be passed to those datasets if customisation is required (But unlikely to be used right now)

Also added a `.gitignore` change to stop notebook runs generating commitable output
