### PR TITLE
feat: allow to write inventory for (stac, osc, all) and expose xarray output

### DIFF
--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -40,6 +40,9 @@ $graph:
       inventory_format:
         type: string
         default: "osc"
+      write_xarray_compatible_zarr:
+        type: boolean
+        default: false
 
     outputs:
       - id: indicator-result
@@ -63,6 +66,7 @@ $graph:
           indicator: indicator
           store: store
           inventory_format: inventory_format
+          write_xarray_compatible_zarr: write_xarray_compatible_zarr
         out:
           - indicator-results
 
@@ -111,12 +115,14 @@ $graph:
         type: string
       inventory_format:
         type: string
+      write_xarray_compatible_zarr:
+        type: boolean
 
     outputs:
       indicator-results:
         type: Directory
         outputBinding:
-          glob: "./indicator"
+          glob: $(inputs.store)
 
     baseCommand: os_climate_hazard
 
@@ -138,3 +144,5 @@ $graph:
         valueFrom: $(inputs.window_years)
       - prefix: --inventory_format
         valueFrom: $(inputs.inventory_format)
+      - prefix: --write-xarray-compatible-zarr
+        valueFrom: $(inputs.write_xarray_compatible_zarr)

--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -76,7 +76,7 @@ $graph:
 
     hints:
       DockerRequirement:
-        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:ukcp18compat
+        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:latest
 
     requirements:
       ResourceRequirement:

--- a/src/hazard/cli.py
+++ b/src/hazard/cli.py
@@ -11,7 +11,7 @@ def days_tas_above_indicator(
     source_dataset_kwargs: Optional[Dict[str, Any]] = None,
     gcm_list: List[str] = ["NorESM2-MM"],
     scenario_list: List[str] = ["ssp585"],
-    threshold_list: List[float] = [20],
+    threshold_list: List[float] = [15],
     central_year_list: List[int] = [2090],
     central_year_historical: int = 2005,
     window_years: int = 1,
@@ -19,7 +19,7 @@ def days_tas_above_indicator(
     prefix: Optional[str] = None,
     store: Optional[str] = None,
     inventory_format: Optional[str] = "osc",
-    extra_xarray_store: Optional[bool] = False,
+    write_xarray_compatible_zarr: Optional[bool] = False,
 ):
     hazard_services.days_tas_above_indicator(
         source_dataset,
@@ -33,7 +33,7 @@ def days_tas_above_indicator(
         bucket,
         prefix,
         store,
-        extra_xarray_store,
+        write_xarray_compatible_zarr,
         inventory_format,
     )
 
@@ -50,7 +50,7 @@ def degree_days_indicator(
     bucket: Optional[str] = None,
     prefix: Optional[str] = None,
     store: Optional[str] = None,
-    extra_xarray_store: Optional[bool] = False,
+    write_xarray_compatible_zarr: Optional[bool] = False,
     inventory_format: Optional[str] = "osc",
 ):
     hazard_services.degree_days_indicator(
@@ -65,7 +65,7 @@ def degree_days_indicator(
         bucket,
         prefix,
         store,
-        extra_xarray_store,
+        write_xarray_compatible_zarr,
         inventory_format,
     )
 


### PR DESCRIPTION
# What this PR is

Pre this PR, you could only choose `STAC` *or* `osc` (inventory.json) output for the indicator inventory

I've now made it so you can choose one or the other *or* both.

I've also exposed the xarray compatible zarr writing in the `cwl` file, I also renamed the parameter

# How to test it

You can run the workflow with the following:

```
cwltool hazard_workflow.cwl#produce-hazard-indicator hazard_workflow_input.yml
```

And inputs:

```
source_dataset: UKCP18
scenario_list: "[rcp85]"
gcm_list: "[ukcp18]"
central_year_list: "[2030]"
central_year_historical: 2030
ceda_ftp_username: yourusername
ceda_ftp_url: "ftp.ceda.ac.uk"
ceda_ftp_password: "yourpassword"
window_years: 20
inventory_format: "all"
write_xarray_compatible_zarr: true
```

And you'll get an output like: 

```
indicator
├── .zgroup
├── .zmetadata
├── catalog.json
├── chronic_heat
│   ├── .zgroup
│   └── osc
│       ├── .zgroup
│       └── v2
│           ├── .zgroup
│           ├── days_tas_above_20c_ukcp18_rcp85_2030
│           │   ├── .zarray
│           │   ├── .zattrs
│           │   └── 0.0.0
│           ├── days_tas_above_20c_ukcp18_rcp85_2030_map
│           │   ├── .zarray
│           │   ├── .zattrs
│           │   └── 0.0.0
│           └── days_tas_above_20c_ukcp18_rcp85_2030_xarray
│               ├── .zattrs
│               ├── .zgroup
│               ├── data
│               │   ├── .zarray
│               │   ├── .zattrs
│               │   └── 0.0
│               ├── latitude
│               │   ├── .zarray
│               │   ├── .zattrs
│               │   └── 0
│               ├── longitude
│               │   ├── .zarray
│               │   ├── .zattrs
│               │   └── 0
│               └── spatial_ref
│                   ├── .zarray
│                   ├── .zattrs
│                   └── 0
├── chronic_heat_osc_v2_days_tas_above_20c_ukcp18_rcp85_2030.json
├── collection.json
└── inventory.json
```
