### PR TITLE
Enable more UKCP18 resolutions and expose dataset kwargs

### DIFF
--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -21,6 +21,9 @@ $graph:
         default: ""
       source_dataset:
         type: string
+      source_dataset_kwargs:
+        type: string
+        default: "{}"
       gcm_list:
         type: string
       scenario_list:
@@ -58,6 +61,7 @@ $graph:
           ceda_ftp_password: ceda_ftp_password
           ceda_ftp_url: ceda_ftp_url
           source_dataset: source_dataset
+          source_dataset_kwargs: source_dataset_kwargs
           gcm_list: gcm_list
           scenario_list: scenario_list
           central_year_list: central_year_list
@@ -99,6 +103,8 @@ $graph:
         type: string
       source_dataset:
         type: string
+      source_dataset_kwargs:
+        type: string
       gcm_list:
         type: string
       scenario_list:
@@ -132,6 +138,8 @@ $graph:
         valueFrom: $(inputs.store)
       - prefix: --source_dataset
         valueFrom: $(inputs.source_dataset)
+      - prefix: --source_dataset_kwargs
+        valueFrom: $(inputs.source_dataset_kwargs)
       - prefix: --gcm_list
         valueFrom: $(inputs.gcm_list)
       - prefix: --scenario_list

--- a/hazard_workflow_input_example.yml
+++ b/hazard_workflow_input_example.yml
@@ -1,6 +1,7 @@
 window_years: 0  # type 'int'
 store: "./indicator"  # default value of type 'string'.
 source_dataset: a_string  # type 'string'
+source_dataset_kwargs: "{'a-key':'a-value','another-key':'another-value'}" # type: string
 scenario_list: a_string  # type 'string'
 indicator: "days_tas_above_indicator"  # default value of type 'string'.
 gcm_list: a_string  # type 'string'

--- a/src/hazard/sources/ukcp18.py
+++ b/src/hazard/sources/ukcp18.py
@@ -12,7 +12,7 @@ from rasterio import CRS
 
 from hazard.protocols import OpenDataset
 
-_UKCP18_2_2km_ROTATED_POLES = """
+_UKCP18_UK_2_2KM_ROTATED_POLES = """
 GEOGCRS["Rotated_pole",
     BASEGEOGCRS["unknown",
         DATUM["unnamed",
@@ -43,6 +43,37 @@ GEOGCRS["Rotated_pole",
             ANGLEUNIT["degree",0.0174532925199433,
                 ID["EPSG",9122]]]]
             """
+_UKCP18_EUR_12KM_ROTATED_POLES = """
+GEOGCRS["Rotated_pole",
+    BASEGEOGCRS["unknown",
+        DATUM["unnamed",
+            ELLIPSOID["Sphere",6371229,0,
+                LENGTHUNIT["metre",1,
+                    ID["EPSG",9001]]]],
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]],
+    DERIVINGCONVERSION["Pole rotation (netCDF CF convention)",
+        METHOD["Pole rotation (netCDF CF convention)"],
+        PARAMETER["Grid north pole latitude (netCDF CF convention)",39.25,
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        PARAMETER["Grid north pole longitude (netCDF CF convention)",198,
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        PARAMETER["North pole grid longitude (netCDF CF convention)",0,
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]],
+    CS[ellipsoidal,2],
+        AXIS["latitude",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        AXIS["longitude",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]]
+"""
 _BRITISH_NATIONAL_GRID = "EPSG:27700"
 _WGS84 = "EPSG:4326"
 
@@ -172,7 +203,19 @@ class Ukcp18(OpenDataset):
         elif self._domain == "uk" and self._resolution == "2.2km":
             prepped_data_array = self._prepare_data_array(
                 dataset[quantity],
-                rasterio.CRS.from_wkt(_UKCP18_2_2km_ROTATED_POLES),
+                rasterio.CRS.from_wkt(_UKCP18_UK_2_2KM_ROTATED_POLES),
+                drop_vars=["latitude", "longitude"],
+            )
+            prepped_data_array.rio.set_spatial_dims(
+                "grid_longitude", "grid_latitude", inplace=True
+            )
+            dataset[quantity] = self._reproject_and_rename_coordinates(
+                prepped_data_array, _WGS84, "x", "y"
+            )
+        elif self._domain == "eur" and self._resolution == "12km":
+            prepped_data_array = self._prepare_data_array(
+                dataset[quantity],
+                rasterio.CRS.from_wkt(_UKCP18_EUR_12KM_ROTATED_POLES),
                 drop_vars=["latitude", "longitude"],
             )
             prepped_data_array.rio.set_spatial_dims(

--- a/src/hazard/sources/ukcp18.py
+++ b/src/hazard/sources/ukcp18.py
@@ -6,11 +6,48 @@ from contextlib import contextmanager
 from typing import Dict, Generator, List, Optional
 
 import fsspec
+import rasterio
 import xarray as xr
+from rasterio import CRS
 
 from hazard.protocols import OpenDataset
 
+_UKCP18_2_2km_ROTATED_POLES = """
+GEOGCRS["Rotated_pole",
+    BASEGEOGCRS["unknown",
+        DATUM["unnamed",
+            ELLIPSOID["Sphere",6371229,0,
+                LENGTHUNIT["metre",1,
+                    ID["EPSG",9001]]]],
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]],
+    DERIVINGCONVERSION["Pole rotation (netCDF CF convention)",
+        METHOD["Pole rotation (netCDF CF convention)"],
+        PARAMETER["Grid north pole latitude (netCDF CF convention)",37.5,
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        PARAMETER["Grid north pole longitude (netCDF CF convention)",177.5,
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        PARAMETER["North pole grid longitude (netCDF CF convention)",0,
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]],
+    CS[ellipsoidal,2],
+        AXIS["latitude",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        AXIS["longitude",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]]
+            """
+_BRITISH_NATIONAL_GRID = "EPSG:27700"
+_WGS84 = "EPSG:4326"
+
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class Ukcp18(OpenDataset):
@@ -18,7 +55,10 @@ class Ukcp18(OpenDataset):
         self,
         dataset_member_id: str = "01",
         dataset_frequency: str = "day",
-        dataset_version: str = "v20190731",
+        dataset_version: str = "latest",
+        collection: str = "land-rcm",
+        domain: str = "uk",
+        resolution: str = "12km",
     ):
         self._fs = fsspec.filesystem(
             protocol="ftp",
@@ -34,6 +74,10 @@ class Ukcp18(OpenDataset):
         self._dataset_member_id = dataset_member_id
         self._dataset_frequency = dataset_frequency
         self._dataset_version = dataset_version
+
+        self._collection = collection
+        self._domain = domain
+        self._resolution = resolution
 
     def gcms(self) -> List[str]:
         return list("ukcp18")
@@ -76,13 +120,13 @@ class Ukcp18(OpenDataset):
                 with io.BytesIO(f.read()) as file_in_memory:
                     file_in_memory.seek(0)
                     datasets.append(xr.open_dataset(file_in_memory).load())
-        return xr.combine_by_coords(datasets)  # type: ignore[return-value]
+        return xr.combine_by_coords(datasets, combine_attrs="override")  # type: ignore[return-value]
 
     def _get_files_available_for_quantity_and_year(
         self, gcm: str, scenario: str, quantity: str, year: int
     ) -> List[str]:
         ftp_url = (
-            f"/badc/{gcm}/data/land-rcm/uk/12km/{scenario}/{self._dataset_member_id}/{quantity}"
+            f"/badc/{gcm}/data/{self._collection}/{self._domain}/{self._resolution}/{scenario}/{self._dataset_member_id}/{quantity}"
             f"/{self._dataset_frequency}/{self._dataset_version}/"
         )
         all_files = self._fs.ls(ftp_url, detail=False)
@@ -97,14 +141,55 @@ class Ukcp18(OpenDataset):
                     files_that_contain_year.append(f"{ftp_url}{file}")
         return files_that_contain_year
 
+    def _prepare_data_array(
+        self, data_array: xr.DataArray, crs: str | CRS, drop_vars: List[str]
+    ) -> xr.DataArray:
+        squeezed = data_array.squeeze()
+        dropped_vars = squeezed.drop_vars(drop_vars, errors="ignore")
+        dropped_vars.attrs.pop("grid_mapping", None)
+        return dropped_vars.rio.write_crs(crs)
+
+    def _reproject_and_rename_coordinates(
+        self,
+        data_array: xr.DataArray,
+        target_crs: str,
+        to_rename_to_lon: str,
+        to_rename_to_lat: str,
+    ) -> xr.DataArray:
+        reprojected = data_array.rio.reproject(target_crs)
+        return reprojected.rename({to_rename_to_lon: "lon", to_rename_to_lat: "lat"})
+
     def _reproject_quantity(self, dataset: xr.Dataset, quantity: str) -> xr.Dataset:
-        squeezed = dataset[quantity].squeeze()
-        no_grid_values = squeezed.drop_vars(["grid_latitude", "grid_longitude"])
-        del no_grid_values.attrs["grid_mapping"]
-        pre_projection = no_grid_values.rio.write_crs("EPSG:27700")
-        reprojected = pre_projection.rio.reproject("EPSG:4326")
-        reprojected_and_renamed = reprojected.rename({"x": "lon", "y": "lat"})
-        dataset[quantity] = reprojected_and_renamed
+        if self._domain == "uk" and self._resolution in ["5km", "12km", "60km"]:
+            prepped_data_array = self._prepare_data_array(
+                dataset[quantity],
+                _BRITISH_NATIONAL_GRID,
+                ["latitude", "longitude", "grid_latitude", "grid_longitude"],
+            )
+            dataset[quantity] = self._reproject_and_rename_coordinates(
+                prepped_data_array, _WGS84, "x", "y"
+            )
+        elif self._domain == "uk" and self._resolution == "2.2km":
+            prepped_data_array = self._prepare_data_array(
+                dataset[quantity],
+                rasterio.CRS.from_wkt(_UKCP18_2_2km_ROTATED_POLES),
+                drop_vars=["latitude", "longitude"],
+            )
+            prepped_data_array.rio.set_spatial_dims(
+                "grid_longitude", "grid_latitude", inplace=True
+            )
+            dataset[quantity] = self._reproject_and_rename_coordinates(
+                prepped_data_array, _WGS84, "x", "y"
+            )
+        elif self._domain == "global" and self._resolution == "60km":
+            prepped_data_array = self._prepare_data_array(dataset[quantity], _WGS84, [])
+            dataset[quantity] = prepped_data_array.rename(
+                {"longitude": "lon", "latitude": "lat"}
+            )
+        else:
+            logger.warning(
+                "Didn't find a matching domain and resolution for reprojecting the dataset, returning it untouched"
+            )
         return dataset
 
     def _convert_to_kelvin(self, dataset: xr.Dataset, quantity: str) -> xr.Dataset:


### PR DESCRIPTION
# What this PR is

This PR adds:

* Multiple resolutions are now available for UKCP18 data, namely the combinations are:
```
collection=land-gcm,resolution=60km,domain=global
collection=land-gcm,resolution=60km,domain=uk
collection=land-rcm,resolution=12km,domain=uk
collection=land-rcm,resolution=12km,domain=eur
collection=land-cpm,resolution=5km,domain=uk
collection=land-cpm,resolution=2.2km,domain=12
```

* Support for `source_dataset_kwargs` to be passed via cwl to the cli (allows for overriding stuff like `collection` etc)

# How to test

Use this example input:

```
source_dataset: UKCP18
source_dataset_kwargs: "{'collection':'land-cpm','resolution':'2.2km','domain':'uk'}"
scenario_list: "[rcp85]"
gcm_list: "[ukcp18]"
central_year_list: "[2030]"
central_year_historical: 2030
ceda_ftp_username: your-user
ceda_ftp_url: "ftp.ceda.ac.uk"
ceda_ftp_password: "your-password"
window_years: 1
inventory_format: "all"
write_xarray_compatible_zarr: true
```