### PR TITLE
fix: apply fixes after doing all UKCP18 runs

### DIFF
--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -28,6 +28,12 @@ $graph:
         type: string
       scenario_list:
         type: string
+      threshold_list:
+        type: string
+        default: "[]"
+      threshold_temperature:
+        type: float
+        default: 0
       central_year_list:
         type: string
       central_year_historical:
@@ -46,6 +52,9 @@ $graph:
       write_xarray_compatible_zarr:
         type: boolean
         default: false
+      dask_cluster_kwargs:
+        type: string
+        default: "{'n_workers': 1, 'threads_per_worker': 1}"
 
     outputs:
       - id: indicator-result
@@ -64,6 +73,8 @@ $graph:
           source_dataset_kwargs: source_dataset_kwargs
           gcm_list: gcm_list
           scenario_list: scenario_list
+          threshold_list: threshold_list
+          threshold_temperature: threshold_temperature
           central_year_list: central_year_list
           central_year_historical: central_year_historical
           window_years: window_years
@@ -71,6 +82,7 @@ $graph:
           store: store
           inventory_format: inventory_format
           write_xarray_compatible_zarr: write_xarray_compatible_zarr
+          dask_cluster_kwargs: dask_cluster_kwargs
         out:
           - indicator-results
 
@@ -109,6 +121,10 @@ $graph:
         type: string
       scenario_list:
         type: string
+      threshold_list:
+        type: string
+      threshold_temperature:
+        type: float
       central_year_list:
         type: string
       central_year_historical:
@@ -123,6 +139,8 @@ $graph:
         type: string
       write_xarray_compatible_zarr:
         type: boolean
+      dask_cluster_kwargs:
+        type: string
 
     outputs:
       indicator-results:
@@ -144,6 +162,10 @@ $graph:
         valueFrom: $(inputs.gcm_list)
       - prefix: --scenario_list
         valueFrom: $(inputs.scenario_list)
+      - prefix: --threshold_list
+        valueFrom: $(inputs.threshold_list)
+      - prefix: --threshold_temperature
+        valueFrom: $(inputs.threshold_temperature)
       - prefix: --central_year_list
         valueFrom: $(inputs.central_year_list)
       - prefix: --central_year_historical
@@ -152,5 +174,7 @@ $graph:
         valueFrom: $(inputs.window_years)
       - prefix: --inventory_format
         valueFrom: $(inputs.inventory_format)
-      - prefix: --write-xarray-compatible-zarr
+      - prefix: --write_xarray_compatible_zarr
         valueFrom: $(inputs.write_xarray_compatible_zarr)
+      - prefix: --dask_cluster_kwargs
+        valueFrom: $(inputs.dask_cluster_kwargs)

--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -92,7 +92,7 @@ $graph:
 
     hints:
       DockerRequirement:
-        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:latest
+        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:10463a7
 
     requirements:
       ResourceRequirement:

--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -92,7 +92,7 @@ $graph:
 
     hints:
       DockerRequirement:
-        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:10463a7
+        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:ee1aa39
 
     requirements:
       ResourceRequirement:

--- a/src/hazard/cli.py
+++ b/src/hazard/cli.py
@@ -20,6 +20,8 @@ def days_tas_above_indicator(
     store: Optional[str] = None,
     inventory_format: Optional[str] = "osc",
     write_xarray_compatible_zarr: Optional[bool] = False,
+    dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ):
     hazard_services.days_tas_above_indicator(
         source_dataset,
@@ -35,6 +37,7 @@ def days_tas_above_indicator(
         store,
         write_xarray_compatible_zarr,
         inventory_format,
+        dask_cluster_kwargs,
     )
 
 
@@ -52,6 +55,8 @@ def degree_days_indicator(
     store: Optional[str] = None,
     write_xarray_compatible_zarr: Optional[bool] = False,
     inventory_format: Optional[str] = "osc",
+    dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ):
     hazard_services.degree_days_indicator(
         source_dataset,
@@ -67,6 +72,7 @@ def degree_days_indicator(
         store,
         write_xarray_compatible_zarr,
         inventory_format,
+        dask_cluster_kwargs,
     )
 
 

--- a/src/hazard/inventory.py
+++ b/src/hazard/inventory.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 import pystac
 from pydantic import BaseModel, Field
 
-
 # region HazardModel
 
 

--- a/src/hazard/inventory.py
+++ b/src/hazard/inventory.py
@@ -1,13 +1,11 @@
 import datetime
 import itertools
 import json
-import logging
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import pystac
 from pydantic import BaseModel, Field
 
-logger = logging.getLogger(__name__)
 
 # region HazardModel
 
@@ -151,7 +149,6 @@ class HazardResource(BaseModel):
         items = []
 
         for p in permutations:
-            logger.info(f"Permutation: {p}")
             items.append(
                 self.to_stac_item(
                     path_root=path_root,

--- a/src/hazard/inventory.py
+++ b/src/hazard/inventory.py
@@ -208,10 +208,15 @@ class HazardResource(BaseModel):
 
         stac_item.validate()
 
+        item_string = json.dumps(stac_item.to_dict())
+        for k, v in combined_parameters.items():
+            item_string = item_string.replace(f"{{{k}}}", str(v))
+        templated_out_item = stac_item.from_dict(json.loads(item_string))
+
         if item_as_dict:
-            return stac_item.to_dict()
+            return templated_out_item.to_dict()
         else:
-            return stac_item
+            return templated_out_item
 
 
 class HazardResources(BaseModel):

--- a/src/hazard/inventory.py
+++ b/src/hazard/inventory.py
@@ -208,15 +208,24 @@ class HazardResource(BaseModel):
 
         stac_item.validate()
 
-        item_string = json.dumps(stac_item.to_dict())
-        for k, v in combined_parameters.items():
-            item_string = item_string.replace(f"{{{k}}}", str(v))
-        templated_out_item = stac_item.from_dict(json.loads(item_string))
+        templated_out_item = self._expand_template_values_for_stac_record(
+            combined_parameters, stac_item
+        )
 
         if item_as_dict:
             return templated_out_item.to_dict()
         else:
             return templated_out_item
+
+    def _expand_template_values_for_stac_record(
+        self, combined_parameters: Dict[Any, str], stac_item: pystac.Item
+    ):
+        item_string = json.dumps(stac_item.to_dict())
+        for k, v in combined_parameters.items():
+            item_string = item_string.replace(f"{{{k}}}", str(v))
+        templated_out_item = stac_item.from_dict(json.loads(item_string))
+        templated_out_item.validate()
+        return templated_out_item
 
 
 class HazardResources(BaseModel):

--- a/src/hazard/inventory.py
+++ b/src/hazard/inventory.py
@@ -1,10 +1,13 @@
 import datetime
 import itertools
 import json
+import logging
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import pystac
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
 
 # region HazardModel
 
@@ -148,6 +151,7 @@ class HazardResource(BaseModel):
         items = []
 
         for p in permutations:
+            logger.info(f"Permutation: {p}")
             items.append(
                 self.to_stac_item(
                     path_root=path_root,
@@ -167,7 +171,6 @@ class HazardResource(BaseModel):
         """
         converts a hazard resource along with combined parameters (params and scenarios) to a single STAC item.
         """
-
         data_asset_path = self.path.format(**combined_parameters)
         item_id = data_asset_path.replace("/", "_")
         osc_properties = self.model_dump()

--- a/src/hazard/services.py
+++ b/src/hazard/services.py
@@ -31,6 +31,7 @@ def days_tas_above_indicator(
     store: Optional[str] = None,
     write_xarray_compatible_zarr: Optional[bool] = False,
     inventory_format: Optional[str] = "osc",
+    dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
 ):
     """
     Run the days_tas_above indicator generation for a list of models,scenarios, thresholds,
@@ -41,7 +42,7 @@ def days_tas_above_indicator(
     """
 
     docs_store, target, client = setup(
-        bucket, prefix, store, write_xarray_compatible_zarr
+        bucket, prefix, store, write_xarray_compatible_zarr, dask_cluster_kwargs
     )
 
     source_dataset_kwargs = (
@@ -77,6 +78,7 @@ def degree_days_indicator(
     store: Optional[str] = None,
     write_xarray_compatible_zarr: Optional[bool] = False,
     inventory_format: Optional[str] = "osc",
+    dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
 ):
     """
     Run the degree days indicator generation for a list of models,scenarios, a threshold temperature,
@@ -87,7 +89,7 @@ def degree_days_indicator(
     """
 
     docs_store, target, client = setup(
-        bucket, prefix, store, write_xarray_compatible_zarr
+        bucket, prefix, store, write_xarray_compatible_zarr, dask_cluster_kwargs
     )
 
     source_dataset_kwargs = (
@@ -126,6 +128,7 @@ def setup(
     prefix: Optional[str] = None,
     store: Optional[str] = None,
     write_xarray_compatible_zarr: Optional[bool] = False,
+    dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Tuple[DocStore, OscZarr, Client]:
     """
     initialize output store, docs store and local dask client
@@ -149,7 +152,8 @@ def setup(
                 write_xarray_compatible_zarr=write_xarray_compatible_zarr,
             )
 
-    cluster = LocalCluster(processes=False)
+    dask_cluster_kwargs = dask_cluster_kwargs or {}
+    cluster = LocalCluster(processes=False, **dask_cluster_kwargs)
 
     client = Client(cluster)
 


### PR DESCRIPTION
# What this PR is

This PR applies several fixes after I ran the UKCP18 Indicator generation for all the inputs we require

## Changes:

* Parameterised `threshold_list` and `threshold_temperature` so we can change them per run config
* Parameterised `dask_cluster_kwargs` so that we can make processing sequential (as needed for memory restricted environments)
* Changed `src/hazard/sources/ukcp18.py`'s `fsspec.filesystem` to be a `filecache` `ftp` implementation. This will store downloaded files under `/tmp/ukcp18cache/` so we don't have to download GB files every year of calculations
* Removed `collection` as a parameter to pass to the `UKCP18` dataset, this can be derived from the desired resolution
* Fixed an issue caused by dynamic CRS handling for `global` `60km` data

# How you can test it

A 'nice' small dataset to test is the UK 60km Days Tas Above, here's an example input file:

```
source_dataset: UKCP18
source_dataset_kwargs: "{'resolution':'60km','domain':'uk'}"
scenario_list: "[rcp85]"
gcm_list: "[ukcp18]"
threshold_list: "[20,25,28,30,32,35,40,45,50,55]"
central_year_list: "[2030,2040,2050,2060,2070,2080,2090]"
central_year_historical: 2005
ceda_ftp_username: <your username>
ceda_ftp_url: "ftp.ceda.ac.uk"
ceda_ftp_password: "<your password>"
window_years: 20
inventory_format: "all"
write_xarray_compatible_zarr: true
store: "./indicator/uk_60km_dta"
indicator: "days_tas_above_indicator"
```

You should get:

[uk_60km_dta_tree.txt](https://github.com/user-attachments/files/16759957/uk_60km_dta_tree.txt)

## 💡Useful note 💡

You can pass `cwltool` where you want `/tmp` in the container to be mounted to, I found this useful for keeping tabs on `/tmp` usage:

```
cwltool --tmpdir-prefix=<PATH_TO_LOCAL_DIR_OF_CHOICE> hazard_workflow.cwl#produce-hazard-indicator input_file.yml
```