### PR TITLE
fix: fix issue where STAC Geometry wasn't a closed LineRing

### DIFF
--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -92,7 +92,7 @@ $graph:
 
     hints:
       DockerRequirement:
-        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:cb86f35
+        dockerPull: public.ecr.aws/c9k5s3u3/os-hazard-indicator:ed6f5d1
 
     requirements:
       ResourceRequirement:


### PR DESCRIPTION
# What this PR is

When the ADES platformed ingested our Items (or at least tried to) it pointed out that our STAC Item geometries were invalid (They were non closed LineRings)

This has sparked a few conversations as:

A: `pystac` didn't find this
B: `staclint` didn't find this

I talked to Pete G and his recommendation was to lean into something like Shapely to validate the actual geo parts. Seen as it was already a dependency in `hazard` I just went with it.

# What I did

* Modified `src/hazard/inventory.py` to close the LineRing **and** added a `shapely.is_valid_reason` call to help catch future issues
* Bumped up the version in CWL

# How you can test it

This is an Item before the fix:

```
{
    "type": "Feature",
    "stac_version": "1.0.0",
    "id": "chronic_heat_osc_v2_days_tas_above_20c_ukcp18_rcp85_2030",
    "properties": {
        "osc-hazard:hazard_type": "ChronicHeat",
        "osc-hazard:group_id": "",
        "osc-hazard:path": "chronic_heat/osc/v2/days_tas_above_20c_ukcp18_rcp85_2030",
        "osc-hazard:indicator_id": "days_tas/above/20c",
        "osc-hazard:indicator_model_id": null,
        "osc-hazard:indicator_model_gcm": "ukcp18",
        "osc-hazard:params": {
            "temp_c": [
                "20",
                "25",
                "28",
                "30",
                "32",
                "35",
                "40",
                "45",
                "50",
                "55"
            ],
            "gcm": [
                "ukcp18"
            ]
        },
        "osc-hazard:display_name": "Days with average temperature above 20\u00b0C/ukcp18",
        "osc-hazard:display_groups": [
            "Days with average temperature above"
        ],
        "osc-hazard:description": "Days per year for which the average near-surface temperature 'tas' is above a threshold specified in \u00b0C.\n\n$$\nI =  \\frac{365}{n_y} \\sum_{i = 1}^{n_y} \\boldsymbol{\\mathbb{1}}_{\\; \\, T^{avg}_i > T^\\text{ref}} \\nonumber\n$$\n\n$I$ is the indicator, $T^\\text{avg}_i$ is the daily average near-surface temperature for day index $i$ in \u00b0C, $n_y$ is the number of days in the year\nand $T^\\text{ref}$ is the reference temperature.\n\nUK Climate Projections (UKCP) by the [Met Office Hadley Centre](https://www.metoffice.gov.uk/research/approach/collaboration/ukcp), sourced from the [Centre for Environmental Data Analysis (CEDA)](http://catalogue.ceda.ac.uk/?q=ukcp18&record_types=Observation&sort_by=relevance). Projections until 2100 on global (60km), 2080 on regional (12km) and local (5km and 2.2km) scales, for a high emissions scenario, RCP8.5.\n\nIndicators are generated for periods: 2030 (2020-2040), 2040 (2030-2050), 2050 (2040-2060), 2060 (2050-2070), 2070 (2060-2080), 2080 (2070-2090), and 2090 (2080-2100).",
        "osc-hazard:map": {
            "colormap": {
                "min_index": 1,
                "min_value": 0.0,
                "max_index": 255,
                "max_value": 100.0,
                "name": "heating",
                "nodata_index": 0,
                "units": "days/year"
            },
            "path": "days_tas_above_20c_ukcp18_rcp85_2030_map",
            "bounds": [
                [
                    -180.0,
                    85.0
                ],
                [
                    180.0,
                    85.0
                ],
                [
                    180.0,
                    -60.0
                ],
                [
                    -180.0,
                    -60.0
                ]
            ],
            "bbox": [
                -180.0,
                -60.0,
                180.0,
                85.0
            ],
            "index_values": null,
            "source": "map_array"
        },
        "osc-hazard:scenarios": [
            {
                "id": "rcp85",
                "years": [
                    2030,
                    2040,
                    2050,
                    2060,
                    2070,
                    2080,
                    2090
                ]
            }
        ],
        "osc-hazard:units": "days/year",
        "start_datetime": "2000-01-01T00:00:00Z",
        "end_datetime": "2100-01-01T00:00:00Z",
        "datetime": null
    },
    "geometry": {
        "type": "Polygon",
        "coordinates": [
            [
                [
                    -180.0,
                    85.0
                ],
                [
                    180.0,
                    85.0
                ],
                [
                    180.0,
                    -60.0
                ],
                [
                    -180.0,
                    -60.0
                ]
            ]
        ]
    },
    "links": [
        {
            "rel": "collection",
            "href": "./collection.json",
            "type": "application/json"
        }
    ],
    "assets": {
        "data": {
            "href": "./chronic_heat/osc/v2/days_tas_above_20c_ukcp18_rcp85_2030",
            "type": "application/vnd+zarr",
            "title": "zarr directory",
            "description": "directory containing indicators data as zarr arrays",
            "roles": [
                "data"
            ]
        }
    },
    "bbox": [
        -180.0,
        -60.0,
        180.0,
        85.0
    ],
    "stac_extensions": [],
    "collection": "osc-hazard-indicators"
}
```

If you take that to [geojson.io](https://geojson.io) it'l say it's not valid

If you take the following one from a run I just did locally, you can see it is:

```
{
    "type": "Feature",
    "stac_version": "1.0.0",
    "stac_extensions": [],
    "id": "chronic_heat_osc_v2_days_tas_above_55c_ukcp18_rcp85_2050",
    "geometry": {
        "type": "Polygon",
        "coordinates": [
            [
                [
                    -180.0,
                    85.0
                ],
                [
                    180.0,
                    85.0
                ],
                [
                    180.0,
                    -60.0
                ],
                [
                    -180.0,
                    -60.0
                ],
                [
                    -180.0,
                    85.0
                ]
            ]
        ]
    },
    "bbox": [
        -180.0,
        -60.0,
        180.0,
        85.0
    ],
    "properties": {
        "osc-hazard:hazard_type": "ChronicHeat",
        "osc-hazard:group_id": "",
        "osc-hazard:path": "chronic_heat/osc/v2/days_tas_above_55c_ukcp18_rcp85_2050",
        "osc-hazard:indicator_id": "days_tas/above/55c",
        "osc-hazard:indicator_model_id": null,
        "osc-hazard:indicator_model_gcm": "ukcp18",
        "osc-hazard:params": {
            "temp_c": [
                "20",
                "25",
                "28",
                "30",
                "32",
                "35",
                "40",
                "45",
                "50",
                "55"
            ],
            "gcm": [
                "ukcp18"
            ]
        },
        "osc-hazard:display_name": "Days with average temperature above 55\u00b0C/ukcp18",
        "osc-hazard:display_groups": [
            "Days with average temperature above"
        ],
        "osc-hazard:description": "Days per year for which the average near-surface temperature 'tas' is above a threshold specified in \u00b0C.\n\n$$\nI =  \\frac{365}{n_y} \\sum_{i = 1}^{n_y} \\boldsymbol{\\mathbb{1}}_{\\; \\, T^{avg}_i > T^\\text{ref}} \\nonumber\n$$\n\n$I$ is the indicator, $T^\\text{avg}_i$ is the daily average near-surface temperature for day index $i$ in \u00b0C, $n_y$ is the number of days in the year\nand $T^\\text{ref}$ is the reference temperature.\n\nUK Climate Projections (UKCP) by the [Met Office Hadley Centre](https://www.metoffice.gov.uk/research/approach/collaboration/ukcp), sourced from the [Centre for Environmental Data Analysis (CEDA)](http://catalogue.ceda.ac.uk/?q=ukcp18&record_types=Observation&sort_by=relevance). Projections until 2100 on global (60km), 2080 on regional (12km) and local (5km and 2.2km) scales, for a high emissions scenario, RCP8.5.\n\nIndicators are generated for periods: 2030 (2020-2040), 2040 (2030-2050), 2050 (2040-2060), 2060 (2050-2070), 2070 (2060-2080), 2080 (2070-2090), and 2090 (2080-2100).",
        "osc-hazard:map": {
            "colormap": {
                "min_index": 1,
                "min_value": 0.0,
                "max_index": 255,
                "max_value": 100.0,
                "name": "heating",
                "nodata_index": 0,
                "units": "days/year"
            },
            "path": "days_tas_above_55c_ukcp18_rcp85_2050_map",
            "bounds": [
                [
                    -180.0,
                    85.0
                ],
                [
                    180.0,
                    85.0
                ],
                [
                    180.0,
                    -60.0
                ],
                [
                    -180.0,
                    -60.0
                ]
            ],
            "bbox": [
                -180.0,
                -60.0,
                180.0,
                85.0
            ],
            "index_values": null,
            "source": "map_array"
        },
        "osc-hazard:scenarios": [
            {
                "id": "rcp85",
                "years": [
                    2030,
                    2040,
                    2050,
                    2060,
                    2070,
                    2080,
                    2090
                ]
            }
        ],
        "osc-hazard:units": "days/year",
        "start_datetime": "2000-01-01T00:00:00Z",
        "end_datetime": "2100-01-01T00:00:00Z",
        "datetime": null
    },
    "links": [
        {
            "rel": "collection",
            "href": "./collection.json",
            "type": "application/json"
        }
    ],
    "assets": {
        "data": {
            "href": "./chronic_heat/osc/v2/days_tas_above_55c_ukcp18_rcp85_2050",
            "type": "application/vnd+zarr",
            "title": "zarr directory",
            "description": "directory containing indicators data as zarr arrays",
            "roles": [
                "data"
            ]
        }
    },
    "collection": "osc-hazard-indicators"
}
```
